### PR TITLE
Feature/reject invalid signature

### DIFF
--- a/lib/attache/api/model.rb
+++ b/lib/attache/api/model.rb
@@ -13,6 +13,7 @@ module Attache
         Utils.array(attr_value).inject([]) do |sum, obj|
           sum + Utils.array(obj && obj.tap {|attrs|
             attrs['url'] = V1.attache_url_for(attrs['path'], geometry)
+            attrs.delete 'signature'
 
             # add signature
             Attache::API::V1.attache_signature_for(attrs) do |generated_signature|

--- a/lib/attache/api/v1.rb
+++ b/lib/attache/api/v1.rb
@@ -83,6 +83,16 @@ module Attache
         raise
       end
 
+      def attache_signature_for(hash)
+        if ATTACHE_SECRET_KEY.to_s.strip != ""
+          hash_without_signature = hash.reject {|k,v| k == 'signature' }
+          content = hash_without_signature.sort.collect {|k,v| "#{k}=#{v}" }.join('&')
+          generated_signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), ATTACHE_SECRET_KEY, content)
+          yield generated_signature if block_given?
+          generated_signature
+        end
+      end
+
       self.extend(self)
     end
   end

--- a/lib/attache/api/version.rb
+++ b/lib/attache/api/version.rb
@@ -1,5 +1,5 @@
 module Attache
   module API
-    VERSION = "1.0.0"
+    VERSION = "2.0.0"
   end
 end

--- a/test/attache/api/model_test.rb
+++ b/test/attache/api/model_test.rb
@@ -3,47 +3,79 @@ require 'test_helper'
 class Attache::API::TestModel < Minitest::Test
   include Attache::API::Model
 
+  def with_secret_key(value)
+    old_value = Attache::API::V1::ATTACHE_SECRET_KEY.dup
+    Attache::API::V1.send(:remove_const, :ATTACHE_SECRET_KEY)
+    Attache::API::V1.send(:const_set, :ATTACHE_SECRET_KEY, value)
+    yield value
+  ensure
+    Attache::API::V1.send(:remove_const, :ATTACHE_SECRET_KEY)
+    Attache::API::V1.send(:const_set, :ATTACHE_SECRET_KEY, old_value)
+  end
+
   def test_attache_field_options
-    assert_equal Hash({
-      data: {
-        geometry: "geometry123",
-        value: [ {"path" => "dirname456/value789", "url" => "#{Attache::API::V1::ATTACHE_DOWNLOAD_URL}/dirname456/geometry123/value789" } ],
-        placeholder: ["placeholder"],
-        uploadurl: Attache::API::V1::ATTACHE_UPLOAD_URL,
-        downloadurl: Attache::API::V1::ATTACHE_DOWNLOAD_URL,
-        key: "value789",
-      },
-    }), attache_field_options(
-      { "path" => "dirname456/value789" },
-      "geometry123",
-      { placeholder: "placeholder", data: { key: "value789" }, auth_options: false }
-    )
+    with_secret_key "" do
+      assert_equal Hash({
+        data: {
+          geometry: "geometry123",
+          value: [ {"path" => "dirname456/value789", "url" => "#{Attache::API::V1::ATTACHE_DOWNLOAD_URL}/dirname456/geometry123/value789" } ],
+          placeholder: ["placeholder"],
+          uploadurl: Attache::API::V1::ATTACHE_UPLOAD_URL,
+          downloadurl: Attache::API::V1::ATTACHE_DOWNLOAD_URL,
+          key: "value789",
+        },
+      }), attache_field_options(
+        { "path" => "dirname456/value789" },
+        "geometry123",
+        { placeholder: "placeholder", data: { key: "value789" }, auth_options: false }
+      )
+    end
   end
 
   def test_attache_field_urls
-    assert_equal ["#{Attache::API::V1::ATTACHE_DOWNLOAD_URL}/dirname456/geometry123/value789"],
-      attache_field_urls( { "path" => "dirname456/value789" }, "geometry123")
+    with_secret_key "" do
+      assert_equal ["#{Attache::API::V1::ATTACHE_DOWNLOAD_URL}/dirname456/geometry123/value789"],
+        attache_field_urls( { "path" => "dirname456/value789" }, "geometry123")
+    end
   end
 
-  def test_attache_field_attributes
-    assert_equal [{"path"=>"dirname456/value789", "url"=>"#{Attache::API::V1::ATTACHE_URL}/view/dirname456/geometry123/value789"}],
-      attache_field_attributes( { "path" => "dirname456/value789" }, "geometry123")
+  def test_attache_field_attributes_without_secret
+    with_secret_key "" do
+      assert_equal [{"path"=>"dirname456/value789", "url"=>"#{Attache::API::V1::ATTACHE_URL}/view/dirname456/geometry123/value789"}],
+        attache_field_attributes( { "path" => "dirname456/value789" }, "geometry123")
+    end
+  end
+
+  def test_attache_field_attributes_with_secret
+    with_secret_key "topsecret" do |secret_key|
+      hash_without_signature = { "path"=>"dirname456/value789", "url"=>"#{Attache::API::V1::ATTACHE_URL}/view/dirname456/geometry123/value789" }
+      content = hash_without_signature.sort.collect {|k,v| "#{k}=#{v}" }.join('&')
+      valid_signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), secret_key, content)
+      assert_equal [hash_without_signature.merge("signature" => valid_signature)],
+        attache_field_attributes( { "path" => "dirname456/value789" }, "geometry123")
+    end
   end
 
   def test_attache_field_set_without_secret
-    assert_equal [{"path"=>"dirname456/value789"}],
-      attache_field_set([{}, "", {"path" => "dirname456/value789"}, nil], secret_key: "")
+    with_secret_key "" do
+      assert_equal [{"path"=>"dirname456/value789"}],
+        attache_field_set([{}, "", {"path" => "dirname456/value789"}, nil])
+    end
   end
 
   def test_attache_field_set_with_secret_valid_signature
-    valid_signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), "topsecret", 'path=dirname456/value789')
-    assert_equal [{"path"=>"dirname456/value789", "signature" => valid_signature}],
-      attache_field_set([{"path" => "dirname456/value789", "signature" => valid_signature}], secret_key: "topsecret")
+    with_secret_key "topsecret" do |secret_key|
+      valid_signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), secret_key, 'path=dirname456/value789')
+      assert_equal [{"path"=>"dirname456/value789"}],
+        attache_field_set([{"path" => "dirname456/value789", "signature" => valid_signature}])
+    end
   end
 
   def test_attache_field_set_with_secret_invalid_signature
-    assert_equal [],
-      attache_field_set([{"path" => "dirname456/value789", "signature" => "wrong"}], secret_key: "topsecret")
+    with_secret_key "topsecret" do |secret_key|
+      assert_equal [],
+        attache_field_set([{"path" => "dirname456/value789", "signature" => "wrong"}])
+    end
   end
 
   def test_attache_update_pending_diffs

--- a/test/attache/api/model_test.rb
+++ b/test/attache/api/model_test.rb
@@ -39,6 +39,13 @@ class Attache::API::TestModel < Minitest::Test
     end
   end
 
+  def test_attache_field_attributes_without_secret_but_has_signature
+    with_secret_key "" do
+      assert_equal [{"path"=>"dirname456/value789", "url"=>"#{Attache::API::V1::ATTACHE_URL}/view/dirname456/geometry123/value789"}],
+        attache_field_attributes( { "path" => "dirname456/value789", "signature" => "lorem ipsum" }, "geometry123")
+    end
+  end
+
   def test_attache_field_attributes_without_secret
     with_secret_key "" do
       assert_equal [{"path"=>"dirname456/value789", "url"=>"#{Attache::API::V1::ATTACHE_URL}/view/dirname456/geometry123/value789"}],

--- a/test/attache/api/model_test.rb
+++ b/test/attache/api/model_test.rb
@@ -4,7 +4,7 @@ class Attache::API::TestModel < Minitest::Test
   include Attache::API::Model
 
   def with_secret_key(value)
-    old_value = Attache::API::V1::ATTACHE_SECRET_KEY.dup
+    old_value = Attache::API::V1::ATTACHE_SECRET_KEY && Attache::API::V1::ATTACHE_SECRET_KEY.dup
     Attache::API::V1.send(:remove_const, :ATTACHE_SECRET_KEY)
     Attache::API::V1.send(:const_set, :ATTACHE_SECRET_KEY, value)
     yield value

--- a/test/attache/api/model_test.rb
+++ b/test/attache/api/model_test.rb
@@ -30,9 +30,20 @@ class Attache::API::TestModel < Minitest::Test
       attache_field_attributes( { "path" => "dirname456/value789" }, "geometry123")
   end
 
-  def test_attache_field_set
+  def test_attache_field_set_without_secret
     assert_equal [{"path"=>"dirname456/value789"}],
-      attache_field_set([{}, "", {"path" => "dirname456/value789"}, nil])
+      attache_field_set([{}, "", {"path" => "dirname456/value789"}, nil], secret_key: "")
+  end
+
+  def test_attache_field_set_with_secret_valid_signature
+    valid_signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), "topsecret", 'path=dirname456/value789')
+    assert_equal [{"path"=>"dirname456/value789", "signature" => valid_signature}],
+      attache_field_set([{"path" => "dirname456/value789", "signature" => valid_signature}], secret_key: "topsecret")
+  end
+
+  def test_attache_field_set_with_secret_invalid_signature
+    assert_equal [],
+      attache_field_set([{"path" => "dirname456/value789", "signature" => "wrong"}], secret_key: "topsecret")
   end
 
   def test_attache_update_pending_diffs

--- a/test/attache/api/v1_test.rb
+++ b/test/attache/api/v1_test.rb
@@ -104,6 +104,7 @@ class Attache::API::TestV1 < Minitest::Test
     end
 
     def remote_response(wait: ENV['REMOTE_RESPONSE_WAIT'].to_i)
+      sleep wait
       response = HTTPClient.get attache_url_for(@uploaded['path'], 'remote')
       assert_equal 302, response.code
       assert response.headers['Location']


### PR DESCRIPTION
Add support for https://github.com/choonkeat/attache/issues/41 by rejecting json if the `signature` attribute is invalid
